### PR TITLE
[Feat] #5 - 메인 화면 PageViewController 구현

### DIFF
--- a/MarketKurly-iOS/MarketKurly-iOS.xcodeproj/project.pbxproj
+++ b/MarketKurly-iOS/MarketKurly-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,11 @@
 		A43BFA2F2A781AF000DCF7B8 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA2E2A781AF000DCF7B8 /* DetailView.swift */; };
 		A43BFA312A781AFE00DCF7B8 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA302A781AFE00DCF7B8 /* DetailViewController.swift */; };
 		A43BFA332A78BED000DCF7B8 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA322A78BED000DCF7B8 /* TabBarItem.swift */; };
+		A43BFA3B2A7956D300DCF7B8 /* RecommendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA3A2A7956D300DCF7B8 /* RecommendViewController.swift */; };
+		A43BFA3D2A7956DD00DCF7B8 /* NewItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA3C2A7956DD00DCF7B8 /* NewItemViewController.swift */; };
+		A43BFA3F2A7956ED00DCF7B8 /* BestItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA3E2A7956ED00DCF7B8 /* BestItemViewController.swift */; };
+		A43BFA412A7956F700DCF7B8 /* ShoppingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA402A7956F700DCF7B8 /* ShoppingViewController.swift */; };
+		A43BFA432A79571A00DCF7B8 /* BenefitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA422A79571A00DCF7B8 /* BenefitViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -76,6 +81,11 @@
 		A43BFA2E2A781AF000DCF7B8 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		A43BFA302A781AFE00DCF7B8 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		A43BFA322A78BED000DCF7B8 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
+		A43BFA3A2A7956D300DCF7B8 /* RecommendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendViewController.swift; sourceTree = "<group>"; };
+		A43BFA3C2A7956DD00DCF7B8 /* NewItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewItemViewController.swift; sourceTree = "<group>"; };
+		A43BFA3E2A7956ED00DCF7B8 /* BestItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestItemViewController.swift; sourceTree = "<group>"; };
+		A43BFA402A7956F700DCF7B8 /* ShoppingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingViewController.swift; sourceTree = "<group>"; };
+		A43BFA422A79571A00DCF7B8 /* BenefitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenefitViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -310,6 +320,11 @@
 			isa = PBXGroup;
 			children = (
 				A43BFA082A77C6B700DCF7B8 /* HomeViewController.swift */,
+				A43BFA342A79568900DCF7B8 /* Recommend */,
+				A43BFA382A7956AE00DCF7B8 /* NewItem */,
+				A43BFA372A7956A500DCF7B8 /* BestItem */,
+				A43BFA362A79569D00DCF7B8 /* Shopping */,
+				A43BFA352A79569400DCF7B8 /* Benefit */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -352,6 +367,46 @@
 				A43BFA2E2A781AF000DCF7B8 /* DetailView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		A43BFA342A79568900DCF7B8 /* Recommend */ = {
+			isa = PBXGroup;
+			children = (
+				A43BFA3A2A7956D300DCF7B8 /* RecommendViewController.swift */,
+			);
+			path = Recommend;
+			sourceTree = "<group>";
+		};
+		A43BFA352A79569400DCF7B8 /* Benefit */ = {
+			isa = PBXGroup;
+			children = (
+				A43BFA422A79571A00DCF7B8 /* BenefitViewController.swift */,
+			);
+			path = Benefit;
+			sourceTree = "<group>";
+		};
+		A43BFA362A79569D00DCF7B8 /* Shopping */ = {
+			isa = PBXGroup;
+			children = (
+				A43BFA402A7956F700DCF7B8 /* ShoppingViewController.swift */,
+			);
+			path = Shopping;
+			sourceTree = "<group>";
+		};
+		A43BFA372A7956A500DCF7B8 /* BestItem */ = {
+			isa = PBXGroup;
+			children = (
+				A43BFA3E2A7956ED00DCF7B8 /* BestItemViewController.swift */,
+			);
+			path = BestItem;
+			sourceTree = "<group>";
+		};
+		A43BFA382A7956AE00DCF7B8 /* NewItem */ = {
+			isa = PBXGroup;
+			children = (
+				A43BFA3C2A7956DD00DCF7B8 /* NewItemViewController.swift */,
+			);
+			path = NewItem;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -435,7 +490,10 @@
 			files = (
 				A43BFA212A78025600DCF7B8 /* CustomNavigationBar.swift in Sources */,
 				A43BF9E52A76464700DCF7B8 /* Search.swift in Sources */,
+				A43BFA3D2A7956DD00DCF7B8 /* NewItemViewController.swift in Sources */,
 				A43BFA032A77C14E00DCF7B8 /* TabBarController.swift in Sources */,
+				A43BFA3B2A7956D300DCF7B8 /* RecommendViewController.swift in Sources */,
+				A43BFA3F2A7956ED00DCF7B8 /* BestItemViewController.swift in Sources */,
 				A43BFA092A77C6B700DCF7B8 /* HomeViewController.swift in Sources */,
 				A43BF9EB2A7646A900DCF7B8 /* HomeEntity.swift in Sources */,
 				A43BF9D52A7645A200DCF7B8 /* UIView+.swift in Sources */,
@@ -460,7 +518,9 @@
 				A43BF9B62A741E3C00DCF7B8 /* SceneDelegate.swift in Sources */,
 				A43BF9D72A7645AC00DCF7B8 /* ImageLiterals.swift in Sources */,
 				A43BFA232A780BBB00DCF7B8 /* HomeView.swift in Sources */,
+				A43BFA412A7956F700DCF7B8 /* ShoppingViewController.swift in Sources */,
 				A43BFA072A77C4FF00DCF7B8 /* UIColor+.swift in Sources */,
+				A43BFA432A79571A00DCF7B8 /* BenefitViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MarketKurly-iOS/MarketKurly-iOS.xcodeproj/project.pbxproj
+++ b/MarketKurly-iOS/MarketKurly-iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,10 @@
 		A43BFA3F2A7956ED00DCF7B8 /* BestItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA3E2A7956ED00DCF7B8 /* BestItemViewController.swift */; };
 		A43BFA412A7956F700DCF7B8 /* ShoppingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA402A7956F700DCF7B8 /* ShoppingViewController.swift */; };
 		A43BFA432A79571A00DCF7B8 /* BenefitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA422A79571A00DCF7B8 /* BenefitViewController.swift */; };
+		A43BFA452A7958C700DCF7B8 /* HomeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA442A7958C700DCF7B8 /* HomeMenu.swift */; };
+		A43BFA482A79594E00DCF7B8 /* HomeMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA472A79594E00DCF7B8 /* HomeMenuItem.swift */; };
+		A43BFA4A2A795C4900DCF7B8 /* HomeMenuCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA492A795C4900DCF7B8 /* HomeMenuCollectionViewCell.swift */; };
+		A43BFA4C2A7966CB00DCF7B8 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43BFA4B2A7966CB00DCF7B8 /* String+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -86,6 +90,10 @@
 		A43BFA3E2A7956ED00DCF7B8 /* BestItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestItemViewController.swift; sourceTree = "<group>"; };
 		A43BFA402A7956F700DCF7B8 /* ShoppingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingViewController.swift; sourceTree = "<group>"; };
 		A43BFA422A79571A00DCF7B8 /* BenefitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenefitViewController.swift; sourceTree = "<group>"; };
+		A43BFA442A7958C700DCF7B8 /* HomeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMenu.swift; sourceTree = "<group>"; };
+		A43BFA472A79594E00DCF7B8 /* HomeMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMenuItem.swift; sourceTree = "<group>"; };
+		A43BFA492A795C4900DCF7B8 /* HomeMenuCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMenuCollectionViewCell.swift; sourceTree = "<group>"; };
+		A43BFA4B2A7966CB00DCF7B8 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +222,7 @@
 				A43BF9FC2A77BC1B00DCF7B8 /* NSObject+.swift */,
 				A43BFA062A77C4FF00DCF7B8 /* UIColor+.swift */,
 				A43BFA0D2A77C81B00DCF7B8 /* UIImage+.swift */,
+				A43BFA4B2A7966CB00DCF7B8 /* String+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -295,6 +304,7 @@
 			children = (
 				A43BFA1F2A78021C00DCF7B8 /* NavigationBar */,
 				A43BF9FF2A77C11100DCF7B8 /* TabBar */,
+				A43BFA462A79593B00DCF7B8 /* HomeMenu */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -409,6 +419,16 @@
 			path = NewItem;
 			sourceTree = "<group>";
 		};
+		A43BFA462A79593B00DCF7B8 /* HomeMenu */ = {
+			isa = PBXGroup;
+			children = (
+				A43BFA442A7958C700DCF7B8 /* HomeMenu.swift */,
+				A43BFA472A79594E00DCF7B8 /* HomeMenuItem.swift */,
+				A43BFA492A795C4900DCF7B8 /* HomeMenuCollectionViewCell.swift */,
+			);
+			path = HomeMenu;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -490,14 +510,18 @@
 			files = (
 				A43BFA212A78025600DCF7B8 /* CustomNavigationBar.swift in Sources */,
 				A43BF9E52A76464700DCF7B8 /* Search.swift in Sources */,
+				A43BFA452A7958C700DCF7B8 /* HomeMenu.swift in Sources */,
 				A43BFA3D2A7956DD00DCF7B8 /* NewItemViewController.swift in Sources */,
 				A43BFA032A77C14E00DCF7B8 /* TabBarController.swift in Sources */,
+				A43BFA4C2A7966CB00DCF7B8 /* String+.swift in Sources */,
+				A43BFA482A79594E00DCF7B8 /* HomeMenuItem.swift in Sources */,
 				A43BFA3B2A7956D300DCF7B8 /* RecommendViewController.swift in Sources */,
 				A43BFA3F2A7956ED00DCF7B8 /* BestItemViewController.swift in Sources */,
 				A43BFA092A77C6B700DCF7B8 /* HomeViewController.swift in Sources */,
 				A43BF9EB2A7646A900DCF7B8 /* HomeEntity.swift in Sources */,
 				A43BF9D52A7645A200DCF7B8 /* UIView+.swift in Sources */,
 				A43BF9DB2A7645D100DCF7B8 /* UITableViewRegiseterable.swift in Sources */,
+				A43BFA4A2A795C4900DCF7B8 /* HomeMenuCollectionViewCell.swift in Sources */,
 				A43BFA2F2A781AF000DCF7B8 /* DetailView.swift in Sources */,
 				A43BF9B82A741E3C00DCF7B8 /* ViewController.swift in Sources */,
 				A43BFA312A781AFE00DCF7B8 /* DetailViewController.swift in Sources */,

--- a/MarketKurly-iOS/MarketKurly-iOS/Global/Extension/String+.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Global/Extension/String+.swift
@@ -1,0 +1,22 @@
+//
+//  String+.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+extension String {
+
+     /// String의 너비를 반환해주는 함수
+     /// - Parameter addPadding: padding값을 더해줄때 사용(기본값 0)
+     /// - Returns: string의 너비값(실제로는 string을 넣은 label의 너비값)
+     func calcuateWidth(addPadding: CGFloat = 0) -> CGFloat {
+         let label = UILabel()
+         label.text = self
+         label.font = .systemFont(ofSize: 16, weight: .regular)
+         label.sizeToFit()
+         return label.frame.width + addPadding
+     }
+ }

--- a/MarketKurly-iOS/MarketKurly-iOS/Global/Extension/String+.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Global/Extension/String+.swift
@@ -15,7 +15,7 @@ extension String {
      func calcuateWidth(addPadding: CGFloat = 0) -> CGFloat {
          let label = UILabel()
          label.text = self
-         label.font = .systemFont(ofSize: 16, weight: .regular)
+         label.font = .systemFont(ofSize: 15, weight: .regular)
          label.sizeToFit()
          return label.frame.width + addPadding
      }

--- a/MarketKurly-iOS/MarketKurly-iOS/Global/Literals/ColorLiterals.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Global/Literals/ColorLiterals.swift
@@ -9,6 +9,10 @@ import UIKit
 
 extension UIColor {
     
+    static var Gray200: UIColor {
+        return UIColor(hex: "#666666")
+    }
+    
     static var Gray400: UIColor {
         return UIColor(hex: "#DDDDDD")
     }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
@@ -25,7 +25,7 @@ final class HomeMenu: UIView {
     
     // MARK: - UI Components
     
-    private var menuCollectionView: UICollectionView = {
+    var menuCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
         flowLayout.minimumInteritemSpacing = 1
@@ -116,6 +116,10 @@ extension HomeMenu {
             $0.height.equalTo(3)
         }
     }
+    
+    func selectMenu(at index: Int) {
+        menuCollectionView.selectItem(at: IndexPath(item: index, section: 0), animated: true, scrollPosition: .centeredHorizontally)
+    }
 }
 
 extension HomeMenu: UICollectionViewDataSource {
@@ -127,6 +131,7 @@ extension HomeMenu: UICollectionViewDataSource {
         guard let cell = menuCollectionView.dequeueReusableCell(withReuseIdentifier: HomeMenuCollectionViewCell.identifier, for: indexPath) as? HomeMenuCollectionViewCell else { return HomeMenuCollectionViewCell()}
         cell.title = menuLabels[indexPath.item]
         cell.setCellSelected(isSelected: selectedIndex == indexPath.item)
+        menuCollectionView.selectItem(at: IndexPath(item: selectedIndex, section: 0), animated: false, scrollPosition: .centeredHorizontally)
         return cell
     }
 }
@@ -140,7 +145,7 @@ extension HomeMenu: UICollectionViewDelegate {
         }
         selectedIndex = indexPath.item
         homeMenuDelegate?.didSelectMenu(at: indexPath.item)
-        collectionView.reloadData()
+        selectMenu(at: indexPath.item)
     }
 }
 

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
@@ -1,0 +1,112 @@
+//
+//  HomeMenu.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+import SnapKit
+
+final class HomeMenu: UIView {
+    
+    private let menuLabels = MenuPageType.allCases.map{ $0.rawValue }
+    
+    private var menuCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .horizontal
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.isScrollEnabled = false
+        return collectionView
+    }()
+    
+    private var underLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private let divideLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = .Gray400
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setDelegate()
+        setCollectionView()
+    }
+    
+    override func draw(_ rect: CGRect) {
+        self.isSelected = 0
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension HomeMenu {
+    func setUI() {
+        self.backgroundColor = .clear
+    }
+    
+    func setHierarchy() {
+        addSubviews(menuCollectionView, divideLine)
+        addSubview(underLine)
+    }
+    
+    func setLayout() {
+        
+        divideLine.snp.makeConstraints {
+            $0.bottom.equalTo(menuCollectionView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+        
+        menuCollectionView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(16)
+        }
+    }
+    
+    func setDelegate() {
+        menuCollectionView.dataSource = self
+        menuCollectionView.delegate = self
+    }
+    
+    func setCollectionView() {
+        menuCollectionView.register(HomeMenuCollectionViewCell.self, forCellWithReuseIdentifier: HomeMenuCollectionViewCell.identifier)
+    }
+}
+
+extension HomeMenu: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return menuLabels.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = menuCollectionView.dequeueReusableCell(withReuseIdentifier: HomeMenuCollectionViewCell.identifier, for: indexPath) as? HomeMenuCollectionViewCell else { return HomeMenuCollectionViewCell()}
+        cell.title = menuLabels[indexPath.item]
+        return cell
+    }
+}
+
+extension HomeMenu: UICollectionViewDelegate {
+}
+
+extension HomeMenu: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: menuLabels[indexPath.row].calcuateWidth(addPadding: 10), height: menuCollectionView.frame.height)
+    }
+}

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
@@ -9,9 +9,15 @@ import UIKit
 
 import SnapKit
 
+protocol HomeMenuDelegate: AnyObject {
+    func didSelectMenu(at index: Int)
+}
+
 final class HomeMenu: UIView {
     
     var selectedIndex: Int = 0
+    
+    weak var homeMenuDelegate: HomeMenuDelegate?
     
     private let menuLabels = MenuPageType.allCases.map{ $0.rawValue }
     
@@ -125,6 +131,7 @@ extension HomeMenu: UICollectionViewDelegate {
             updateUnderLine(index: indexPath.item, padding: leading)
         }
         selectedIndex = indexPath.item
+        homeMenuDelegate?.didSelectMenu(at: indexPath.item)
         collectionView.reloadData()
     }
 }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
@@ -9,6 +9,8 @@ import UIKit
 
 import SnapKit
 
+// MARK: - Protocol
+
 protocol HomeMenuDelegate: AnyObject {
     func didSelectMenu(at index: Int)
 }
@@ -20,6 +22,8 @@ final class HomeMenu: UIView {
     weak var homeMenuDelegate: HomeMenuDelegate?
     
     private let menuLabels = MenuPageType.allCases.map{ $0.rawValue }
+    
+    // MARK: - UI Components
     
     private var menuCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
@@ -44,6 +48,8 @@ final class HomeMenu: UIView {
         return view
     }()
     
+    // MARK: - Life Cycles
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -59,6 +65,8 @@ final class HomeMenu: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+// MARK: - Extensions
 
 extension HomeMenu {
     func setUI() {

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
@@ -16,17 +16,17 @@ final class HomeMenu: UIView {
     private var menuCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
+        flowLayout.minimumInteritemSpacing = 1
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         collectionView.backgroundColor = .clear
         collectionView.showsVerticalScrollIndicator = false
-        collectionView.isScrollEnabled = false
         return collectionView
     }()
     
     private var underLine: UIView = {
         let view = UIView()
-        view.backgroundColor = .clear
+        view.backgroundColor = .KurlyPurple
         return view
     }()
     
@@ -46,10 +46,6 @@ final class HomeMenu: UIView {
         setCollectionView()
     }
     
-    override func draw(_ rect: CGRect) {
-        self.isSelected = 0
-    }
-    
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -67,6 +63,13 @@ extension HomeMenu {
     }
     
     func setLayout() {
+        
+        underLine.snp.makeConstraints {
+            $0.leading.equalTo(menuCollectionView.snp.leading)
+            $0.bottom.equalTo(menuCollectionView.snp.bottom)
+            $0.width.equalTo(menuLabels[0].calcuateWidth(addPadding: 20))
+            $0.height.equalTo(3)
+        }
         
         divideLine.snp.makeConstraints {
             $0.bottom.equalTo(menuCollectionView.snp.bottom)
@@ -88,6 +91,15 @@ extension HomeMenu {
     func setCollectionView() {
         menuCollectionView.register(HomeMenuCollectionViewCell.self, forCellWithReuseIdentifier: HomeMenuCollectionViewCell.identifier)
     }
+    
+    func updateUnderLine(index: Int, padding: CGFloat) {
+        underLine.snp.remakeConstraints {
+            $0.leading.equalToSuperview().inset(padding+16)
+            $0.bottom.equalTo(menuCollectionView.snp.bottom)
+            $0.width.equalTo(menuLabels[index].calcuateWidth(addPadding: 20))
+            $0.height.equalTo(3)
+        }
+    }
 }
 
 extension HomeMenu: UICollectionViewDataSource {
@@ -103,10 +115,17 @@ extension HomeMenu: UICollectionViewDataSource {
 }
 
 extension HomeMenu: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout,
+           let attributes = layout.layoutAttributesForItem(at: indexPath) {
+            let leading = attributes.frame.origin.x
+            updateUnderLine(index: indexPath.item, padding: leading)
+        }
+    }
 }
 
 extension HomeMenu: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: menuLabels[indexPath.row].calcuateWidth(addPadding: 10), height: menuCollectionView.frame.height)
+        return CGSize(width: menuLabels[indexPath.item].calcuateWidth(addPadding: 20), height: menuCollectionView.frame.height)
     }
 }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenu.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class HomeMenu: UIView {
     
+    var selectedIndex: Int = 0
+    
     private let menuLabels = MenuPageType.allCases.map{ $0.rawValue }
     
     private var menuCollectionView: UICollectionView = {
@@ -110,6 +112,7 @@ extension HomeMenu: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = menuCollectionView.dequeueReusableCell(withReuseIdentifier: HomeMenuCollectionViewCell.identifier, for: indexPath) as? HomeMenuCollectionViewCell else { return HomeMenuCollectionViewCell()}
         cell.title = menuLabels[indexPath.item]
+        cell.setCellSelected(isSelected: selectedIndex == indexPath.item)
         return cell
     }
 }
@@ -121,6 +124,8 @@ extension HomeMenu: UICollectionViewDelegate {
             let leading = attributes.frame.origin.x
             updateUnderLine(index: indexPath.item, padding: leading)
         }
+        selectedIndex = indexPath.item
+        collectionView.reloadData()
     }
 }
 

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuCollectionViewCell.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuCollectionViewCell.swift
@@ -57,7 +57,7 @@ extension HomeMenuCollectionViewCell {
     
     func setLayout() {
         menuTitleLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview().inset(10)
+            $0.centerX.equalToSuperview()
             $0.centerY.equalToSuperview()
         }
     }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuCollectionViewCell.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuCollectionViewCell.swift
@@ -61,4 +61,12 @@ extension HomeMenuCollectionViewCell {
             $0.centerY.equalToSuperview()
         }
     }
+    
+    func setCellSelected(isSelected: Bool) {
+        if isSelected {
+            menuTitleLabel.textColor = .KurlyPurple
+        } else {
+            menuTitleLabel.textColor = .Gray200
+        }
+    }
 }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuCollectionViewCell.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuCollectionViewCell.swift
@@ -1,0 +1,64 @@
+//
+//  HomeMenuCollectionViewCell.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+import SnapKit
+
+final class HomeMenuCollectionViewCell: UICollectionViewCell {
+    
+    static let identifier = "HomeMenuCollectionViewCell"
+    
+    var title: String? {
+        didSet {
+            menuTitleLabel.text = title
+        }
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            menuTitleLabel.textColor = isSelected ? .KurlyPurple : .Gray200
+        }
+    }
+    
+    lazy var menuTitleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .Gray200
+        label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+}
+
+extension HomeMenuCollectionViewCell {
+    func setHierarchy() {
+        addSubview(menuTitleLabel)
+    }
+    
+    func setLayout() {
+        menuTitleLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview().inset(10)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuItem.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/HomeMenu/HomeMenuItem.swift
@@ -1,0 +1,32 @@
+//
+//  HomeMenuItem.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+ @frozen
+ enum MenuPageType: String, CaseIterable {
+     case recommend = "컬리추천"
+     case newItem = "신상품"
+     case bestItem = "베스트"
+     case shopping = "알뜰쇼핑"
+     case benefit = "특가/혜택"
+
+     var viewController: UIViewController {
+         switch self {
+         case .recommend:
+             return RecommendViewController()
+         case .newItem:
+             return NewItemViewController()
+         case .bestItem:
+             return BestItemViewController()
+         case .shopping:
+             return ShoppingViewController()
+         case .benefit:
+             return BenefitViewController()
+         }
+     }
+ }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/NavigationBar/CustomNavigationBar.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/Common/NavigationBar/CustomNavigationBar.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class CustomNavigationBar: UIView {
     
+    // MARK: - UI Components
+    
     public var isNotLeftButtonIncluded: Bool {
         get { !leftButton.isHidden }
         set { leftButton.isHidden = !newValue
@@ -93,10 +95,11 @@ final class CustomNavigationBar: UIView {
         return view
     }()
     
+    // MARK: - Life Cycles
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-//        setUI()
         setLayout()
     }
     
@@ -105,19 +108,12 @@ final class CustomNavigationBar: UIView {
     }
 }
 
+// MARK: - Extensions
+
 extension CustomNavigationBar {
-//    func setUI() {
-//        self.backgroundColor = .PrimaryPurple
-//    }
-    
     func setLayout() {
-//        self.addSubviews(leftButton, logoImageView, detailTitleLabel, naviButton, cartButton)
         navigationView.addSubviews(leftButton, logoImageView, detailTitleLabel,searchTitleLabel, naviButton, cartButton)
         self.addSubviews(backView, navigationView)
-//
-//        self.snp.makeConstraints {
-//            $0.height.equalTo(94)
-//        }
         
         backView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/View/HomeView.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/View/HomeView.swift
@@ -18,6 +18,11 @@ final class HomeView: UIView {
         return view
     }()
     
+    lazy var homeMenuView: HomeMenu = {
+        let view = HomeMenu()
+        return view
+    }()
+    
     // MARK: - Life Cycles
     
     override init(frame: CGRect) {
@@ -40,12 +45,18 @@ private extension HomeView {
     }
     
     func setLayout() {
-        self.addSubview(navigationBarView)
+        self.addSubviews(navigationBarView, homeMenuView)
         
         navigationBarView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(SizeLiterals.Screen.screenHeight * 94 / 812)
+        }
+        
+        homeMenuView.snp.makeConstraints {
+            $0.top.equalTo(navigationBarView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
         }
     }
 }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Benefit/BenefitViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Benefit/BenefitViewController.swift
@@ -1,0 +1,31 @@
+//
+//  BenefitViewController.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+class BenefitViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .yellow
+        
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/BestItem/BestItemViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/BestItem/BestItemViewController.swift
@@ -1,0 +1,31 @@
+//
+//  BestItemViewController.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+class BestItemViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .brown
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -91,6 +91,17 @@ extension HomeViewController: UIPageViewControllerDelegate {
         guard let currentVC = pageViewController.viewControllers?.first,
               let currentIndex = dataViewController.firstIndex(of: currentVC) else { return }
         currentPage = currentIndex
+        
+        if completed {
+            if let selectedViewController = pageViewController.viewControllers?.first,
+               let selectedIndex = dataViewController.firstIndex(of: selectedViewController) {
+                homeView.homeMenuView.menuCollectionView.selectItem(at: IndexPath(item: selectedIndex, section: 0), animated: true, scrollPosition: .centeredHorizontally)
+                
+                let attributes = homeView.homeMenuView.menuCollectionView.layoutAttributesForItem(at: IndexPath(item: selectedIndex, section: 0))
+                let leading = attributes!.frame.origin.x
+                homeView.homeMenuView.updateUnderLine(index: selectedIndex, padding: leading)
+            }
+        }
     }
 }
 

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -45,6 +45,8 @@ final class HomeViewController: UIViewController {
     }
 }
 
+// MARK: - Extensions
+
 extension HomeViewController {
     func setHierarchy() {
         addChild(pageViewController)

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -70,8 +70,17 @@ extension HomeViewController {
     }
     
     func setDelegate() {
+        homeView.homeMenuView.homeMenuDelegate = self
+        
         pageViewController.delegate = self
         pageViewController.dataSource = self
+    }
+}
+
+extension HomeViewController: HomeMenuDelegate {
+    func didSelectMenu(at index: Int) {
+        let selectedViewController = dataViewController[index]
+        pageViewController.setViewControllers([selectedViewController], direction: .forward, animated: true, completion: nil)
     }
 }
 

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 final class HomeViewController: UIViewController {
 
     // MARK: - UI Components
@@ -17,11 +19,84 @@ final class HomeViewController: UIViewController {
         return .lightContent
     }
     
+    lazy var pageViewController: UIPageViewController = {
+        let vc = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        return vc
+    }()
+    
+    var dataViewController: [UIViewController] = []
+    var currentPage = 0
+    
     // MARK: - Life Cycles
     
     override func loadView() {
         super.loadView()
         
         view = homeView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setHierarchy()
+        setLayout()
+        setPageViewController()
+        setDelegate()
+    }
+}
+
+extension HomeViewController {
+    func setHierarchy() {
+        addChild(pageViewController)
+        view.addSubview(pageViewController.view)
+    }
+    
+    func setPageViewController() {
+        pageViewController.didMove(toParent: self)
+        pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        dataViewController = MenuPageType.allCases.map{ $0.viewController }
+        
+        if let firstVC = dataViewController.first {
+            pageViewController.setViewControllers([firstVC], direction: .forward, animated: true, completion: nil)
+        }
+    }
+    
+    func setLayout() {
+        pageViewController.view.snp.makeConstraints {
+            $0.top.equalTo(homeView.homeMenuView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 592 / 812)
+        }
+    }
+    
+    func setDelegate() {
+        pageViewController.delegate = self
+        pageViewController.dataSource = self
+    }
+}
+
+extension HomeViewController: UIPageViewControllerDelegate {
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        guard let currentVC = pageViewController.viewControllers?.first,
+              let currentIndex = dataViewController.firstIndex(of: currentVC) else { return }
+        currentPage = currentIndex
+    }
+}
+
+extension HomeViewController: UIPageViewControllerDataSource {
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let index = dataViewController.firstIndex(of: viewController) else { return nil }
+        let previousIndex = index - 1
+        if previousIndex < 0 {
+            return nil
+        }
+        return dataViewController[previousIndex]
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let index = dataViewController.firstIndex(of: viewController) else { return nil }
+        let nextIndex = index + 1
+        guard nextIndex != dataViewController.count else { return nil }
+        return dataViewController[nextIndex]
     }
 }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/NewItem/NewItemViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/NewItem/NewItemViewController.swift
@@ -1,0 +1,31 @@
+//
+//  NewItemViewController.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+class NewItemViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .blue
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Recommend/RecommendViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Recommend/RecommendViewController.swift
@@ -11,6 +11,8 @@ class RecommendViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        view.backgroundColor = .systemMint
 
         // Do any additional setup after loading the view.
     }

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Recommend/RecommendViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Recommend/RecommendViewController.swift
@@ -1,0 +1,29 @@
+//
+//  RecommendViewController.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+class RecommendViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Shopping/ShoppingViewController.swift
+++ b/MarketKurly-iOS/MarketKurly-iOS/Presentation/HomeScene/ViewController/Shopping/ShoppingViewController.swift
@@ -1,0 +1,31 @@
+//
+//  ShoppingViewController.swift
+//  MarketKurly-iOS
+//
+//  Created by 고아라 on 2023/08/02.
+//
+
+import UIKit
+
+class ShoppingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .orange
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#5

👷 **작업한 내용**
- HomeMenu 구현
- PageViewController 구현
- PageViewController 화면 스크롤 시 HomeMenu에도 반영되는 코드 작성 !
```swift
extension HomeViewController: UIPageViewControllerDelegate {
    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
        if completed {
            if let selectedViewController = pageViewController.viewControllers?.first,
               let selectedIndex = dataViewController.firstIndex(of: selectedViewController) {
                homeView.homeMenuView.menuCollectionView.selectItem(at: IndexPath(item: selectedIndex, section: 0), animated: true, scrollPosition: .centeredHorizontally)
                
                let attributes = homeView.homeMenuView.menuCollectionView.layoutAttributesForItem(at: IndexPath(item: selectedIndex, section: 0))
                let leading = attributes!.frame.origin.x
                homeView.homeMenuView.updateUnderLine(index: selectedIndex, padding: leading)
            }
        }
    }
}
```
위와 같이 작성해 준 후 HomeMenu에서 아래의 코드도 작성해주고 didSelect할 때 함께 호출해 주어야 한다!!
```swift
    func selectMenu(at index: Int) {
        menuCollectionView.selectItem(at: IndexPath(item: index, section: 0), animated: true, scrollPosition: .centeredHorizontally)
    }
```
UIPageViewController의 didFinishAnimating에서 해당 페이지로 전환된 시점을 감지
-> 이에 해당하는 HomeMenuCollectionView의 셀을 selectMenu 메서드를 통해 강제로 업데이트해줘야 하기 때문이다.

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src ="https://github.com/MarketKurly-CloneCoding/MarketKurly-iOS-ahra/assets/79412889/5d7c5a91-a16f-4b08-ae4c-39e058f1caeb" width ="250">|

📟 **관련 이슈**
- Resolved: #5 